### PR TITLE
投稿できる画像の数と解像度の変更

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -80,7 +80,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def process_status_params
     @status_parser = ActivityPub::Parser::StatusParser.new(@json, followers_collection: @account.followers_url, object: @object)
 
-    attachment_ids = process_attachments.take(Status::MEDIA_ATTACHMENTS_LIMIT).map(&:id)
+    attachment_ids = process_attachments.take(Status::MEDIA_ATTACHMENTS_LIMIT_REMOTE).map(&:id)
 
     @params = {
       uri: @status_parser.uri,
@@ -241,7 +241,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     as_array(@object['attachment']).each do |attachment|
       media_attachment_parser = ActivityPub::Parser::MediaAttachmentParser.new(attachment)
 
-      next if media_attachment_parser.remote_url.blank? || media_attachments.size >= Status::MEDIA_ATTACHMENTS_LIMIT
+      next if media_attachment_parser.remote_url.blank? || media_attachments.size >= Status::MEDIA_ATTACHMENTS_LIMIT_REMOTE
 
       begin
         media_attachment = MediaAttachment.create(

--- a/app/models/concerns/attachmentable.rb
+++ b/app/models/concerns/attachmentable.rb
@@ -5,8 +5,8 @@ require 'mime/types/columnar'
 module Attachmentable
   extend ActiveSupport::Concern
 
-  MAX_MATRIX_LIMIT = 33_177_600 # 7680x4320px or approx. 847MB in RAM
-  GIF_MATRIX_LIMIT = 921_600    # 1280x720px
+  MAX_MATRIX_LIMIT = 201_326_592 # 20MP or approx. 847MB in RAM
+  GIF_MATRIX_LIMIT = 921_600 # 1280x720px
 
   # For some file extensions, there exist different content
   # type variants, and browsers often send the wrong one,

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -39,7 +39,7 @@ class MediaAttachment < ApplicationRecord
 
   MAX_DESCRIPTION_LENGTH = 1_500
 
-  IMAGE_LIMIT = 16.megabytes
+  IMAGE_LIMIT = 32.megabytes
   VIDEO_LIMIT = 99.megabytes
 
   MAX_VIDEO_MATRIX_LIMIT = 8_294_400 # 3840x2160px

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -39,7 +39,8 @@ class Status < ApplicationRecord
   include Status::SnapshotConcern
   include Status::ThreadingConcern
 
-  MEDIA_ATTACHMENTS_LIMIT = 4
+  MEDIA_ATTACHMENTS_LIMIT = 8
+  MEDIA_ATTACHMENTS_LIMIT_REMOTE = 4
 
   rate_limit by: :account, family: :statuses
 
@@ -288,7 +289,11 @@ class Status < ApplicationRecord
     else
       map = media_attachments.index_by(&:id)
       ordered_media_attachment_ids.filter_map { |media_attachment_id| map[media_attachment_id] }
-    end.take(MEDIA_ATTACHMENTS_LIMIT)
+    end.take(media_attachments_max)
+  end
+
+  def media_attachments_max
+    local? ? MEDIA_ATTACHMENTS_LIMIT : MEDIA_ATTACHMENTS_LIMIT_REMOTE
   end
 
   def replies_count

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -73,6 +73,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
       statuses: {
         max_characters: StatusLengthValidator::MAX_CHARS,
         max_media_attachments: Status::MEDIA_ATTACHMENTS_LIMIT,
+        max_media_attachments_remote: Status::MEDIA_ATTACHMENTS_LIMIT_REMOTE,
         characters_reserved_per_url: StatusLengthValidator::URL_PLACEHOLDER_CHARS,
       },
 

--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -65,6 +65,7 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
       statuses: {
         max_characters: StatusLengthValidator::MAX_CHARS,
         max_media_attachments: Status::MEDIA_ATTACHMENTS_LIMIT,
+        max_media_attachemnts_remote: Status::MEDIA_ATTACHMENTS_LIMIT_REMOTE,
         characters_reserved_per_url: StatusLengthValidator::URL_PLACEHOLDER_CHARS,
       },
 

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -73,7 +73,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
     as_array(@json['attachment']).each do |attachment|
       media_attachment_parser = ActivityPub::Parser::MediaAttachmentParser.new(attachment)
 
-      next if media_attachment_parser.remote_url.blank? || @next_media_attachments.size > Status::MEDIA_ATTACHMENTS_LIMIT
+      next if media_attachment_parser.remote_url.blank? || @next_media_attachments.size > Status::MEDIA_ATTACHMENTS_LIMIT_REMOTE
 
       begin
         media_attachment   = previous_media_attachments.find { |previous_media_attachment| previous_media_attachment.remote_url == media_attachment_parser.remote_url }


### PR DESCRIPTION
# 変更内容
- このインスタンス内で、一度に投稿できる画像の数を 8 枚に増やした
- 画像の解像度を最大 200 MP までに増やした
- 画像の容量を最大 32 MB までに増やした